### PR TITLE
Added distutils setup.py to the python Fieldtrip Buffer.

### DIFF
--- a/dataAcq/buffer/python/setup.py
+++ b/dataAcq/buffer/python/setup.py
@@ -1,9 +1,15 @@
 from distutils.core import setup
 
-setup(name='FieldTrip',
+try:
+    import numpy
+
+    setup(name='FieldTrip',
       version='1.0',
       description='Python Fieldtrip Client',
       author='S. Klanke',
       url='https://github.com/jadref/buffer_bci/',
-      py_modules = ['FieldTrip'],
+      py_modules = ['FieldTrip']
      )
+except ImportError:
+    print "FieldTrip buffer requires numpy."
+


### PR DESCRIPTION
Hey Jason

Got tired of navigating to the /buffer_bci/dataAq/buffer/python folder each time I wanted to use the python client (which I tended to use for quick tests), so I created a setup.py file that allow you to install the FieldTrip module using distutils. Now I can import FieldTrip anywhere, not just in that one folder.

Figured it may be useful for others, so here's a pull request.

Cheers,

Wieke
